### PR TITLE
Fixed protobuf errors when reading very large networks. Fixes#5260.

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlNetFileV0002.h
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetFileV0002.h
@@ -59,7 +59,7 @@ namespace Isis {
    *                           toPvl() when unable to find TargetRadii values. Instead, we
    *                           will just leave these values blank. References #3892
    *   @history 2017-12-07 Jesse Mapel - Changed how often read streams are recreated to avoid
-   *                           protobuf errors.
+   *                           protobuf errors. Fixes #5260.
    */
   class ControlNetFileV0002 : public ControlNetFile {
     public:

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetFileV0002.h
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetFileV0002.h
@@ -58,6 +58,8 @@ namespace Isis {
    *   @history 2016-04-22 Jeannie Backer - Removed thrown exception in
    *                           toPvl() when unable to find TargetRadii values. Instead, we
    *                           will just leave these values blank. References #3892
+   *   @history 2017-12-07 Jesse Mapel - Changed how often read streams are recreated to avoid
+   *                           protobuf errors.
    */
   class ControlNetFileV0002 : public ControlNetFile {
     public:


### PR DESCRIPTION
This is a temporary fix to avoid protobuf errors when reading very large control networks.

What was happening is that we were reusing one of protobuf's input streams that maintains an internal buffer. With very large control points (read lots of measures) this was bumping into the buffer size limit imposed by protobuf for security reasons. Changing how we reuse these streams fixes the problem.

This code will actually be removed once the ControlNet memory and speed improvements are merged in.