### PR TITLE
Added convenience methods to ControlPoint

### DIFF
--- a/isis/src/control/objs/ControlPoint/ControlPoint.cpp
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.cpp
@@ -619,6 +619,16 @@ namespace Isis {
 
 
   /**
+   * Checks to see if a reference measure is set. 
+   *
+   * @returns bool True if a reference measure is set. 
+   */
+  bool ControlPoint::HasRefMeasure() const {
+    return !(referenceMeasure == NULL): 
+  }
+
+
+  /**
    * Get the reference control measure.
    *
    * @returns const reference measure for this point
@@ -1405,6 +1415,36 @@ namespace Isis {
 
 
   /**
+   * Gets the adjusted x coordinate.
+   * 
+   * @return Displacement The adjusted x coordinate.
+   */
+  Displacement ContorlPoint::GetAdjustedX() const { 
+    return adjustedSurfacePoint.GetX();
+  }
+
+
+  /**
+   * Gets the adjusted y coordinate.
+   * 
+   * @return Displacement The adjusted y coordinate.
+   */
+  Displacement ContorlPoint::GetAdjustedY() const { 
+    return adjustedSurfacePoint.GetY();
+  }
+
+
+  /**
+   * Gets the adjusted z coordinate.
+   * 
+   * @return Displacement The adjusted z coordinate.
+   */
+  Displacement ContorlPoint::GetAdjustedZ() const { 
+    return adjustedSurfacePoint.GetZ();
+  }
+
+
+  /**
    * Returns the adjusted surface point if it exists, otherwise returns
    * the a priori surface point.
    */
@@ -1676,6 +1716,35 @@ namespace Isis {
     return aprioriSurfacePoint;
   }
 
+  /**
+   * Gets the apriori x coordinate.
+   * 
+   * @return Displacement The apriori x coordinate.
+   */
+  Displacement ContorlPoint::GetAprioriX() const { 
+    return aprioriSurfacePoint.GetX();
+  }
+
+
+  /**
+   * Gets the apriori y coordinate.
+   * 
+   * @return Displacement The apriori y coordinate.
+   */
+  Displacement ContorlPoint::GetAprioriY() const { 
+    return aprioriSurfacePoint.GetY();
+  }
+
+
+  /**
+   * Gets the apriori z coordinate.
+   * 
+   * @return Displacement The apriori z coordinate.
+   */
+  Displacement ContorlPoint::GetAprioriZ() const { 
+    return aprioriSurfacePoint.GetZ();
+  }
+
 
   ControlPoint::RadiusSource::Source ControlPoint::GetAprioriRadiusSource()
   const {
@@ -1690,6 +1759,23 @@ namespace Isis {
 
     return false;
   }
+
+  
+  /**
+   * Checks to see if the ControlPoint has an adjusted SurfacePoint.
+   * 
+   * @return bool True if the control point has adjusted x, y, and z coordinates.
+   */
+  bool ControlPoint::HasAdjustedCoordinates() {
+    if (adjustedSurfacePoint.GetX().isValid() &&
+        adjustedSurfacePoint.GetY().isValid() &&
+        adjustedSurfacePoint.GetZ().isValid()) {
+      return true;
+    }
+
+    return false;
+  }
+
 
   bool ControlPoint::IsConstrained() {
     return constraintStatus.any();
@@ -1711,6 +1797,17 @@ namespace Isis {
     return constraintStatus.count();
   }
 
+
+ /**
+  * Checks to see if the radius source file has been set.  
+  *  
+  * @return bool True if the radius source file has been set.
+  */
+  bool ControlPoint::HasAprioriRadiusSourceFile() const {
+    return !( aprioriRadiusSourceFile.isEmpty() || aprioriRadiusSourceFile.isNull() );
+  }
+
+
   QString ControlPoint::GetAprioriRadiusSourceFile() const {
     return aprioriRadiusSourceFile;
   }
@@ -1718,6 +1815,16 @@ namespace Isis {
   ControlPoint::SurfacePointSource::Source
   ControlPoint::GetAprioriSurfacePointSource() const {
     return aprioriSurfacePointSource;
+  }
+
+
+ /**
+  * Checks to see if the surface point source file has been set.  
+  *  
+  * @return bool True if the surface point source file has been set.
+  */
+  bool HasAprioriSurfacePointSourceFile() const {
+    return !( aprioriSurfacePointSourceFile.isEmpty() || aprioriSurfacePointSourceFile.isNull() );
   }
 
 

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -334,7 +334,11 @@ namespace Isis {
    *                           made sure the comparisons are being done correctly. Fixes #1014.
    *   @history 2015-11-05 Kris Becker - invalid flag was not properly
    *                           initialized in ControlPointFileEntryV0002 
-   *                           constructor (Merged by Kristin Berry. Fixes #2392) 
+   *                           constructor (Merged by Kristin Berry. Fixes #2392)
+   *   @history 2017-12-18 Kristin Berry - Added convenience methods:
+   *                            HasAprioriSurfacePointSourceFile(), HasAprioriRadiusSourceFile(),
+   *                            GetAprioriX(), GetAprioriY(), GetAprioriZ(), HasAdjustedCoordinates(),
+   *                            AdjustedX(), AdjustedY(), AdjustedZ(), HasRefMeasure().
    */
   class ControlPoint : public QObject {
 
@@ -460,6 +464,7 @@ namespace Isis {
       const ControlMeasure *GetMeasure(int index) const;
       ControlMeasure *GetMeasure(int index);
 
+      bool HasRefMeasure() const; 
       const ControlMeasure *GetRefMeasure() const;
       ControlMeasure *GetRefMeasure();
 
@@ -501,6 +506,8 @@ namespace Isis {
       bool IsFixed() const;
 
       bool HasAprioriCoordinates();
+      bool HasAdjustedCoordinates();
+
       bool IsConstrained();
       bool IsLatitudeConstrained();
       bool IsLongitudeConstrained();
@@ -519,11 +526,16 @@ namespace Isis {
       static QString SurfacePointSourceToString(SurfacePointSource::Source source);
       static SurfacePointSource::Source StringToSurfacePointSource(QString str);
       QString GetSurfacePointSourceString() const;
-
       SurfacePoint GetAprioriSurfacePoint() const;
+      Displacement GetAprioriX() const;
+      Displacement GetAprioriY() const;
+      Displacement GetAprioriZ() const;
+
       RadiusSource::Source GetAprioriRadiusSource() const;
+      bool HasAprioriRadiusSourceFile() const; 
       QString GetAprioriRadiusSourceFile() const;
       SurfacePointSource::Source GetAprioriSurfacePointSource() const;
+      bool HasAprioriSurfacePointSourceFile() const; 
       QString GetAprioriSurfacePointSourceFile() const;
 
       int GetNumMeasures() const;

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -338,7 +338,7 @@ namespace Isis {
    *   @history 2017-12-18 Kristin Berry - Added convenience methods:
    *                            HasAprioriSurfacePointSourceFile(), HasAprioriRadiusSourceFile(),
    *                            GetAprioriX(), GetAprioriY(), GetAprioriZ(), HasAdjustedCoordinates(),
-   *                            AdjustedX(), AdjustedY(), AdjustedZ(), HasRefMeasure().
+   *                            GetAdjustedX(), GetAdjustedY(), GetAdjustedZ(), HasRefMeasure().
    */
   class ControlPoint : public QObject {
 
@@ -494,6 +494,10 @@ namespace Isis {
       Status ComputeResiduals_Millimeters();
 
       SurfacePoint GetAdjustedSurfacePoint() const;
+      Displacement GetAdjustedX() const;
+      Displacement GetAdjustedY() const;
+      Displacement GetAdjustedZ() const;
+
       SurfacePoint GetBestSurfacePoint() const;
       QString GetChooserName() const;
       QString GetDateTime() const;


### PR DESCRIPTION
Added convenience methods to `ControlPoint` so they can be used by they can be used by `ControlNetVersioner::write()` and `ControlNetVersioner::toPvl()`.

I used `Get`-prefixes for accessors, even though that's not ISIS3 coding standards-compatible because that is consistent with the naming convention within `ControlPoint.`