### PR TITLE
Fixed how ControlMeasureLogData is handled in ControlNetVersioner

### DIFF
--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
@@ -766,7 +766,7 @@ namespace Isis {
    * Return Residual magnitude. Returns Isis:Null when p_lineResidual or p_sampleResidual not
    * specifically set after call to constructor. (This calculation is normally done within the
    * jigsaw app)
-   * 
+   *
    * @returns (double) The residual magnitude
    */
   double ControlMeasure::GetResidualMagnitude() const {
@@ -845,6 +845,20 @@ namespace Isis {
     }
 
     return ControlMeasureLogData(typedDataType);
+  }
+
+
+  /**
+   * Return all of the log data for the measure.
+   *
+   * @return @b QVector<ControlMeasureLogData> All of the log data for the measure.
+   */
+  QVector<ControlMeasureLogData> ControlMeasure::GetLogDataEntries() const {
+    QVector<ControlMeasureLogData> logs;
+    if (p_loggedData) {
+      logs = p_loggedData;
+    }
+    return logs;
   }
 
 
@@ -1018,72 +1032,72 @@ namespace Isis {
 
     return sPrintable;
   }
-  
+
   //! Returns true if the ControlMeasure has a choosername
   bool ControlMeasure::HasChooserName() const {
     return !p_chooserName->isEmpty();
   }
- 
+
   //! Returns true if the ControlMeasure has a datetime
   bool ControlMeasure::HasDateTime() const {
-    return !p_dateTime->isEmpty();   
+    return !p_dateTime->isEmpty();
   }
-  
+
   //! Returns true if the ControlMeasure has a sample
   bool ControlMeasure::HasSample() const {
-    return p_sample ? true : false;   
+    return p_sample ? true : false;
   }
-    
+
   //! Returns true if the ControlMeasure has a line
   bool ControlMeasure::HasLine() const {
-    return p_line ? true : false;    
+    return p_line ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has a diameter
   bool ControlMeasure::HasDiameter() const {
-    return p_diameter ? true : false;   
+    return p_diameter ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has apriorisample
   bool ControlMeasure::HasAprioriSample() const {
     return p_aprioriSample ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has aprioriline
   bool ControlMeasure::HasAprioriLine() const {
     return p_aprioriLine ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has a sample sigma
   bool ControlMeasure::HasSampleSigma() const {
     return p_sampleSigma ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has a line sigma
   bool ControlMeasure::HasLineSigma() const {
     return p_lineSigma ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has a sample residual
   bool ControlMeasure::HasSampleResidual() const {
     return p_sampleResidual ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure has a line residual
   bool ControlMeasure::HasLineResidual() const {
     return p_lineResidual ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure's jigsaw rejected is initialized
   bool ControlMeasure::HasJigsawRejected() const {
-    return p_jigsawRejected ? true : false; 
+    return p_jigsawRejected ? true : false;
   }
-  
+
   //! Returns true if the ControlMeasure is jigsaw rejected
   bool ControlMeasure::JigsawRejected() const {
     return p_jigsawRejected ? true : false;
   }
- 
+
   //! Returns the logsize of the ControlMeasure logged data.
   int ControlMeasure::LogSize() const {
     return p_loggedData->size();
@@ -1184,12 +1198,12 @@ namespace Isis {
    *
    * @author sprasad (4/20/2010)
    *
-   * @internal 
+   * @internal
    *   @history 2010-06-24 Tracie Sucharski, Added new keywords
    *   @history 2012-07-26 Tracie Sucharski, Fixed bug in comparison of chooserName and dateTime,
    *                          comparison was between the pointers instead of the data and added
    *                          comparisons for missing member data.
-   *             
+   *
    *
    * @param pMeasure - Control Measure to be compared against
    *

--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.h
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.h
@@ -152,13 +152,13 @@ namespace Isis {
    *                              does math on special pixels.
    *   @history 2011-04-11 Steven Lambright - Added GetLogValue for convenience
    *   @history 2011-07-05 Debbie A. Cook - Removed editLock checks from methods
-   *                              SetCamera, SetRejected, and SetResidual and 
+   *                              SetCamera, SetRejected, and SetResidual and
    *                              changed all other editLock tests to use
    *                              IsEditLocked method instead of the private
    *                              member, p_editLock, directly.  Also added
    *                              a check for an implicit lock if the measure is
    *                              the reference measure of the parent point in
-   *                              the IsEditLocked method.  
+   *                              the IsEditLocked method.
    *   @history 2011-07-29 Jai Rideout, Steven Lambright, and Eric Hyer - Made
    *                           this inherit from QObject to get destroyed()
    *                           signal
@@ -168,6 +168,8 @@ namespace Isis {
    *   @history 2012-08-11 Tracie Sucharski, Add computed and measured ephemeris time set to Null
    *                           in InitializeToNull.
    *   @history 2017-12-19 Adam Goins - Added "HasX()" accessors to ControlMeasure.
+   *   @history 2017-12-20 Jesse Mapel - Implemented GetLogDataEntries method for use in
+   *                           ControlNetVersioner refactor.
    */
   class ControlMeasure : public QObject {
 
@@ -306,7 +308,7 @@ namespace Isis {
       double GetSampleShift() const;
       double GetLineShift() const;
       double GetPixelShift() const;
-      
+
       bool HasChooserName() const;
       bool HasDateTime() const;
       bool HasSample() const;

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -247,7 +247,7 @@ namespace Isis {
                         controlPoint.GetAprioriRadiusSourceFile());
         }
 
-      if (controlPoint->HasAprioriCoordinates()) { 
+      if (controlPoint->HasAprioriCoordinates()) {
         pvlPoint += PvlKeyword("AprioriX", toString(controlPoint.GetAprioriX()), "meters");
         pvlPoint += PvlKeyword("AprioriY", toString(controlPoint.GetAprioriY()), "meters");
         pvlPoint += PvlKeyword("AprioriZ", toString(controlPoint.GetAprioriZ()), "meters");
@@ -413,7 +413,7 @@ namespace Isis {
           pvlMeasure += PvlKeyword("Ignore", "True");
         }
 
-        if (controlMeasure.HasSample()) { 
+        if (controlMeasure.HasSample()) {
           pvlMeasure += PvlKeyword("Sample", toString(controlMeasure.GetSample()));
 
         }
@@ -1955,7 +1955,7 @@ namespace Isis {
       newMeasure->SetLogData(logEntry);
     }
     return newMeasure;
-  } 
+  }
 
 
   /**
@@ -1992,9 +1992,9 @@ namespace Isis {
       delete [] blankLabel;
 
       streampos startCoreHeaderPos = output.tellp();
-      
+
       OStreamOutputStream *fileStream(output);
-      
+
       writeHeader(fileStream);
 
       BigInt pointByteTotal = 0;
@@ -2025,9 +2025,9 @@ namespace Isis {
       protoCore.addKeyword(PvlKeyword("HeaderBytes", toString((BigInt) coreHeaderSize)));
 
       BigInt pointsStartByte = (BigInt) (startCoreHeaderPos + coreHeaderSize);
-      
+
       protoCore.addKeyword(PvlKeyword("PointsStartByte", toString(pointsStartByte)));
-                        
+
       protoCore.addKeyword(PvlKeyword("PointsBytes",
                            toString(pointByteTotal)));
       protoObj.addObject(protoCore);
@@ -2057,9 +2057,9 @@ namespace Isis {
       output << p;
       output << '\n';
       output.close();
-    } 
+    }
     catch (Exception e) {
-      QString msg = "Can't write control net file"; 
+      QString msg = "Can't write control net file";
       throw IException(IException::Io, msg, _FILEINFO_);
     }
   }
@@ -2187,7 +2187,7 @@ namespace Isis {
 
         }
       }
-      
+
 
       protoPoint.set_latitudeconstrained(controlPoint->IsLatitudeConstrained());
       protoPoint.set_longitudeconstrained(controlPoint->IsLongitudeConstrained());
@@ -2207,9 +2207,9 @@ namespace Isis {
           protoPoint.add_adjustedcovar(controlPoint->AdjustedCovar(3));
           protoPoint.add_adjustedcovar(controlPoint->AdjustedCovar(4));
           protoPoint.add_adjustedcovar(controlPoint->AdjustedCovar(5));
-          }
         }
-      
+      }
+
 
       // Converting Measures
       for (int j = 0; j < controlPoint->GetNumMeasures(); j++) {
@@ -2232,19 +2232,19 @@ namespace Isis {
             case (ControlMeasure::MeasureType::Candidate):
                 protoMeasure.set_measuretype(ControlPointFileEntryV0005_Measure_MeasureType_Candidate);
                 break;
-            
+
             case (ControlMeasure::MeasureType::Manual):
                 protoMeasure.set_measuretype(ControlPointFileEntryV0005_Measure_MeasureType_Manual);
                 break;
-            
+
             case (ControlMeasure::RegisteredPixel):
                 protoMeasure.set_measuretype(ControlPointFileEntryV0005_Measure_MeasureType_RegisteredPixel);
                 break;
-            
+
             case (ControlMeasure::RegisteredSubPixel):
                 protoMeasure.set_measuretype(ControlPointFileEntryV0005_Measure_MeasureType_RegisteredSubPixel);
                 break;
-        }        
+        }
 
         if (controlMeasure.HasChooserName()) {
           protoMeasure.set_choosername(controlMeasure.GetChooserName());
@@ -2298,24 +2298,21 @@ namespace Isis {
         // in ControlPoint.
         protoMeasure.set_jigsawrejected(controlMeasure.JigsawRejected()));
 
-
+        QVector<ControlMeasureLogData> measureLogs = controlMeasure.GetLogDataEntries();
         for (int logEntry = 0;
-            logEntry < controlMeasure.LogSize(); // DNE?
+            logEntry < measureLogs.size(); // DNE?
             logEntry ++) {
 
-          const ControlMeasureLogData &log =
-                controlMeasure.GetLogData(logEntry); // Not sure this is right.
+          const ControlMeasureLogData &log = measureLogs[i];
 
           // These methods might not not exist, we may need to wrap each of These
           // In if/else statements because they're optional values.
           ControlPointFileEntryV0005_Measure_MeasureLogData logData;
 
-          logData.set_doubledatatype(log.GetDoubleDataType());
-          logData.set_doubledatavalue(log.GetDoubleDataValue());
-          logData.set_booldatatype(log.GetBoolDataType());
-          logData.set_booldatavalue(log.getBoolDataValue());
+          logData.set_doubledatatype( (int) log.GetDataType() );
+          logData.set_doubledatavalue( log.GetNumericalValue() );
 
-          protoMeasure.add_log(logData);
+          *protoMeasure.add_log() = logData;
         }
 
         if (controlPoint->HasRefMeasure() && controlPoint->IndexOfRefMeasure() == j) {
@@ -2329,7 +2326,7 @@ namespace Isis {
 
       int msgSize(protoPoint.ByteSize());
       fileStream.WriteVarint32(msgSize);
-      
+
       if ( !protoPoint.SerializeToCodedStream(fileStream.data()) ) {
         QString err = "Error writing to coded protobuf stream";
         throw IException(IException::Programmer, err, _FILEINFO_);

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -1412,7 +1412,10 @@ namespace Isis {
     }
 
     for (int i = 0; i < measure.log_size(); i++) {
-      ControlMeasureLogData logEntry(measure.log(i));
+      const ControlPointFileEntryV0002_Measure_MeasureLogData &protoLog = measure.log(i);
+      ControlMeasureLogData logEntry
+      logEntry.SetNumericalValue( protoLog.doubledatavalue() );
+      logEntry.SetDataType( (ControlMeasureLogData::NumericLogDataType) protoLog.doubledatatype() );
       newMeasure->SetLogData(logEntry);
     }
     return newMeasure;


### PR DESCRIPTION
We still need to remove the old constructor and ToProtobuf methods