### PR TITLE
Removed exceptions thrown when reading in ControlPoints without location info

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -94,10 +94,7 @@ namespace Isis {
       m_pointData->set_adjustedy( toDouble(pointObject["Longitude"][0]) );
       m_pointData->set_adjustedz( toDouble(pointObject["Radius"][0]) );
     }
-    else {
-      QString msg = "Unable to find adjusted surface point values for the control point.";
-      throw IException(IException::Io, msg, _FILEINFO_);
-    }
+
 
     // copy over the apriori surface point
     if ( pointObject.hasKeyword("AprioriLatitude")
@@ -119,10 +116,6 @@ namespace Isis {
       m_pointData->set_apriorix( m_pointData->adjustedx() );
       m_pointData->set_aprioriy( m_pointData->adjustedy() );
       m_pointData->set_aprioriz( m_pointData->adjustedz() );
-    }
-    else {
-      QString msg = "Unable to find apriori surface point values for the control point.";
-      throw IException(IException::Io, msg, _FILEINFO_);
     }
 
     // Ground points were previously flagged by the Held keyword being true.


### PR DESCRIPTION
I removed throws for not being able to populate Apriori or Adjusted surface points when reading in a v1 pvl control network.

The test data for ControlNetDiff, cnet.pvl starts with: 

````
Object = ControlNetwork
  NetworkId    = Test
  TargetName   = Mars
  UserName     = TSucharski
  Created      = 2010-07-10T12:50:15
  LastModified = 2010-07-10T12:50:55
  Description  = "UnitTest of ControlNetwork"

  Object = ControlPoint
    PointType   = Tie
    PointId     = T0001
    ChooserName = autoseed
    DateTime    = 2010-08-27T17:10:06
    Ignore      = True
````
This control point is valid (I assume, since we used this for test data), but doesn't contain enough info to populate Apriori or Adjusted surface point information. So, if this is valid, we shouldn't throw exceptions when we encounter data of this form. 

