### PR TITLE
Revert "Removed exceptions thrown when reading in ControlPoints without location info"

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -94,7 +94,10 @@ namespace Isis {
       m_pointData->set_adjustedy( toDouble(pointObject["Longitude"][0]) );
       m_pointData->set_adjustedz( toDouble(pointObject["Radius"][0]) );
     }
-
+    else {
+      QString msg = "Unable to find adjusted surface point values for the control point.";
+      throw IException(IException::Io, msg, _FILEINFO_);
+    }
 
     // copy over the apriori surface point
     if ( pointObject.hasKeyword("AprioriLatitude")
@@ -116,6 +119,10 @@ namespace Isis {
       m_pointData->set_apriorix( m_pointData->adjustedx() );
       m_pointData->set_aprioriy( m_pointData->adjustedy() );
       m_pointData->set_aprioriz( m_pointData->adjustedz() );
+    }
+    else {
+      QString msg = "Unable to find apriori surface point values for the control point.";
+      throw IException(IException::Io, msg, _FILEINFO_);
     }
 
     // Ground points were previously flagged by the Held keyword being true.


### PR DESCRIPTION
Reverts USGS-Astrogeology/ISIS3#62

After further looking at this, I think our old test data was incorrectly missing `Version = 3` and we should retain these exceptions. 