### PR TITLE
Fixed undefined reference to deleted accessors in ControlMeasure.h

### DIFF
--- a/isis/src/control/objs/ControlMeasure/unitTest.cpp
+++ b/isis/src/control/objs/ControlMeasure/unitTest.cpp
@@ -27,9 +27,9 @@ int main() {
    * @history 2010-08-12  Tracie Sucharski,  Keywords changed AGAIN..
    * @history 2010-10-18  Tracie Sucharski,  Set EditLock to false before
    *                         Test 5 so type can be updatem.
-   * @history 2010-11-03  Mackenzie Boyd,  Added test for PrintableClassData() 
-   * @history 2012-07-26  Tracie Sucharski,  Added test for == and != operators. 
-   * @history 2017-12-21  Kristin Berry - Added tests for accessor methods. 
+   * @history 2010-11-03  Mackenzie Boyd,  Added test for PrintableClassData()
+   * @history 2012-07-26  Tracie Sucharski,  Added test for == and != operators.
+   * @history 2017-12-21  Kristin Berry - Added tests for accessor methods.
    *
   */
   Preference::Preferences(true);
@@ -89,8 +89,8 @@ int main() {
   QList< QStringList > printableMeasureData = m.PrintableClassData();
   QStringList nameValuePair;
   foreach(nameValuePair, printableMeasureData) {
-    qDebug() << nameValuePair.at(0).toStdString() << "=" <<
-        nameValuePair.at(1).toStdString();
+    qDebug() << nameValuePair.at(0).toLatin1().data() << "=" <<
+        nameValuePair.at(1).toLatin1().data();
   }
 
   qDebug() << "Test 8";
@@ -172,63 +172,63 @@ int main() {
     e.print();
   }
 
-  qDebug(); 
-  qDebug() << "Test 14: Testing accessor methods"; 
+  qDebug();
+  qDebug() << "Test 14: Testing accessor methods";
 
 //  if (m.HasChooserName()) {
 //    qDebug() << "Chooser Name: " << m.GetChooserName();
 //  }
 //
 //  if (m.HasDateTime()) {
-//    qDebug() << "DateTime: " << m.GetDateTime(); 
+//    qDebug() << "DateTime: " << m.GetDateTime();
 //  }
 //
 //  if (m.HasSample()) {
-//    qDebug() << "Sample: " << m.GetSample(); 
+//    qDebug() << "Sample: " << m.GetSample();
 //  }
 //
 //  if (m.HasLine()) {
-//    qDebug() << "Line: " << m.GetLine(); 
+//    qDebug() << "Line: " << m.GetLine();
 //  }
 //
 //  if (m.HasDiameter()) {
-//    qDebug() << "Diameter: " << m.GetDiameter(); 
+//    qDebug() << "Diameter: " << m.GetDiameter();
 //  }
 //
 //  if (m.HasAprioriSample()) {
-//    qDebug() << "AprioriSample: " << m.GetAprioriSample(); 
+//    qDebug() << "AprioriSample: " << m.GetAprioriSample();
 //  }
 //
 //  if (m.HasAprioriLine()) {
-//    qDebug() << "AprioriLine: " << m.GetAprioriLine(); 
+//    qDebug() << "AprioriLine: " << m.GetAprioriLine();
 //  }
 //
 //  if (m.HasSampleSigma()) {
-//    qDebug() << "SampleSigma: " << m.GetSampleSigma(); 
+//    qDebug() << "SampleSigma: " << m.GetSampleSigma();
 //  }
 //
 //  if (m.HasLineSigma()) {
-//    qDebug() << "LineSigma: " << m.GetLineSigma(); 
+//    qDebug() << "LineSigma: " << m.GetLineSigma();
 //  }
 //
 //  if (m.HasSampleResidual()) {
-//    qDebug() << "SampleResidual: " << m.GetSampleResidual(); 
+//    qDebug() << "SampleResidual: " << m.GetSampleResidual();
 //  }
 //
 //  if (m.HasLineResidual()) {
-//    qDebug() << "LineResidual: " << m.GetLineResidual(); 
+//    qDebug() << "LineResidual: " << m.GetLineResidual();
 //  }
 //
   if (m.IsRejected()) {
     if (m.JigsawRejected()) {
-      qDebug() << "Measure was rejected by Jigsaw."; 
+      qDebug() << "Measure was rejected by Jigsaw.";
     }
     else {
-      qDebug() << "Measure was not rejected by Jigsaw."; 
+      qDebug() << "Measure was not rejected by Jigsaw.";
     }
   }
 
-  qDebug() << "Log Size: " << m.LogSize(); 
+  qDebug() << "Log Size: " << m.LogSize();
 }
 
 void outit(ControlMeasure &m) {

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -34,7 +34,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
 
   LatestControlNetFile * test = NULL;
   LatestControlNetFile * test2 = NULL;
-  
+
   try {
 
     // If we're reading in a Pvl file, this will call the Pvl update cycle, then
@@ -56,7 +56,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     // Test the latest binary read/write and Pvl conversion
     qDebug() << "Write the network and re-read it...";
     ControlNetVersioner::Write(FileName("./tmp"), *test);
-          
+
     try {
       test2 = ControlNetVersioner::Read(FileName("./tmp"));
     }
@@ -65,8 +65,8 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
       throw;
     }
 
-    qDebug() << "After reading and writing to a binary form does Pvl match?"
-        ;
+    qDebug() << "After reading and writing to a binary form does Pvl match?";
+    
     if(printNetwork) {
       Pvl pvlVersion2(test2->toPvl());
       pvlVersion2.write("./tmp2.pvl");
@@ -80,8 +80,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
 
     ControlNetVersioner::Write(FileName("./tmp2"), *test2);
     if(system("cmp ./tmp ./tmp2")) {
-      qDebug() << "Reading/Writing control network results in binary differences!"
-          ;
+      qDebug() << "Reading/Writing control network results in binary differences!";
     }
     else {
       qDebug() << "Reading/Writing control network is consistent";
@@ -90,7 +89,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     if (pvlInput) {
 
       LatestControlNetFile * cNet2 = NULL;
-      
+
       qDebug() << "Check conversions between the binary format and the pvl format.";
       /*
        * When the input is a pvl, ./tmp is the binary form of the initial input. (pvl1->bin1)
@@ -100,7 +99,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
        *
        *                                  a       b       c
        *                            (pvl1 -> bin1 -> pvl2 -> bin2)
-       * 
+       *
        * if (pvl1 != pvl2)
        *        a or b is broken but we don't know which yet
        *        if(bin1 != bin2)
@@ -111,7 +110,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
        * else
        *        The conversions are up to date and correct because neither a nor b broke.
        *
-       * 
+       *
        */
       cNet2 = ControlNetVersioner::Read(FileName("./tmp.pvl"));
 
@@ -120,7 +119,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
       //if there are differences between the pvls.
       QString cmd = "diff -EbB --suppress-common-lines " + filename + " ./tmp.pvl";
       if(system(cmd.toStdString().c_str())) {
-        
+
         //if the binary files are different.
         if(system("diff -EbB --suppress-common-lines ./tmp ./tmpCNet2")){
           qDebug() << "The conversion from binary to pvl is incorrect.";
@@ -164,4 +163,3 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
 
   qDebug();
 }
-

--- a/isis/src/control/objs/ControlPoint/unitTest.cpp
+++ b/isis/src/control/objs/ControlPoint/unitTest.cpp
@@ -30,10 +30,10 @@ void printPoint(ControlPoint &p);
   * @history 2011-06-07 Debbie A. Cook and Tracie Sucharski - Modified point types
   *                         Ground ------> Fixed
   *                         Tie----------> Free
-  * @history 2015-02-17  Andrew Stebenne, changed a reference to a local filesystem to a dummy file 
+  * @history 2015-02-17  Andrew Stebenne, changed a reference to a local filesystem to a dummy file
   *                         (dummy.cub) to make it clearer that the .cub file being referenced
   *                         wasn't necessary.
-  * @history 2017-12-21 Kristin Berry - Added tests for newly added accessor methods. 
+  * @history 2017-12-21 Kristin Berry - Added tests for newly added accessor methods.
   */
 int main() {
   Preference::Preferences(true);
@@ -130,7 +130,7 @@ int main() {
   printPoint(assignment);
 
   // Should be successful
-  qDebug() << "Deleting ControlMeasure with cube serial number [" << cp.getCubeSerialNumbers().at(0).toStdString() << "]";
+  qDebug() << "Deleting ControlMeasure with cube serial number [" << cp.getCubeSerialNumbers().at(0).toLatin1().data() << "]";
   qDebug() << "Measure type: " << ControlMeasure::MeasureTypeToString(cp.GetMeasure(0)->GetType());
   cp.Delete(0);
   printPoint(cp);
@@ -270,13 +270,13 @@ int main() {
 //
 //  if (cp.HasAprioriCoordinates()) {
 //    qDebug() << "AprioriCoordinates: (" << cp.GetAprioriX().meters() << ", "
-//                                    << cp.GetAprioriY().meters() << ", " 
+//                                    << cp.GetAprioriY().meters() << ", "
 //                                    << cp.GetAprioriZ().meters() << ")";
 //  }
 //
 //  if (cp.HasAdjustedCoordinates()) {
 //    qDebug() << "AdjustedCoordinates: (" << cp.GetAdjustedX().meters() << ", "
-//                                     << cp.GetAdjustedY().meters() << ", " 
+//                                     << cp.GetAdjustedY().meters() << ", "
 //                                     << cp.GetAdjustedZ().meters() << ")";
 //  }
 //


### PR DESCRIPTION
also fixed some coding standard pursuant to PR#67 (Changed QString.toStdString() references to toLatin1().data(), etc). 

ControlNetVersioner unit tests were changed to remove references to LatestControlNetFile