### PR TITLE
Fixed ControlMeasure unitTests

### DIFF
--- a/isis/src/control/objs/ControlMeasure/unitTest.cpp
+++ b/isis/src/control/objs/ControlMeasure/unitTest.cpp
@@ -164,7 +164,6 @@ int main() {
     qDebug() << "Measure1 != Measure2   FALSE";
   }
 
-
   try {
     m.SetLogData(ControlMeasureLogData());
   }
@@ -219,16 +218,17 @@ int main() {
 //    qDebug() << "LineResidual: " << m.GetLineResidual();
 //  }
 //
-  if (m.IsRejected()) {
-    if (m.JigsawRejected()) {
-      qDebug() << "Measure was rejected by Jigsaw.";
-    }
-    else {
-      qDebug() << "Measure was not rejected by Jigsaw.";
-    }
-  }
+//  qDebug() << "Log Size: " << m.LogSize();
 
-  qDebug() << "Log Size: " << m.LogSize();
+  if (m.IsRejected()) {
+  //  if (m.JigsawRejected()) {
+      qDebug() << "Measure was rejected by Jigsaw.";
+  }
+  else {
+      qDebug() << "Measure was not rejected by Jigsaw.";
+  }
+  //}
+
 }
 
 void outit(ControlMeasure &m) {
@@ -244,6 +244,6 @@ void outit(ControlMeasure &m) {
   net.SetModifiedDate("Yesterday");
   net.Write("./tmp.net", true);
   Pvl tmp("./tmp.net");
-  qDebug() << "Printing measure:\n" << tmp << "\nDone printing measure.";
+  std::cout << "Printing measure:\n" << tmp << "\nDone printing measure." << std::endl;
   remove("./tmp.net");
 }

--- a/isis/src/control/objs/ControlMeasure/unitTest.cpp
+++ b/isis/src/control/objs/ControlMeasure/unitTest.cpp
@@ -222,10 +222,10 @@ int main() {
 
   if (m.IsRejected()) {
   //  if (m.JigsawRejected()) {
-      qDebug() << "Measure was rejected by Jigsaw.";
+      qDebug() << "Measure was rejected.";
   }
   else {
-      qDebug() << "Measure was not rejected by Jigsaw.";
+      qDebug() << "Measure was not rejected.";
   }
   //}
 

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -501,7 +501,8 @@ namespace Isis {
         }
 
         if ( controlPoint->HasRefMeasure() &&
-           controlPoint->IndexOfRefMeasure() == j ) {
+           controlPoint->IndexOfRefMeasure() == j &&
+           controlPoint->IsReferenceExplicit() ) {
           pvlMeasure += PvlKeyword("Reference", "True");
         }
         pvlPoint.addGroup(pvlMeasure);


### PR DESCRIPTION
Discrepancy was that "Reference = True" was written out to the control measures when writing to PVL.

Solution was to made a call to ControlPoint::IsReferenceExplicit() before writing "Reference = True"


Commented out code for deleted accessors in ControlMeasure/unitTest.cpp