### PR TITLE
Initialize Sample, Line to Isis::Null instead of zero and fix ControlMeasure's initialization.

### DIFF
--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
@@ -53,8 +53,8 @@ namespace Isis {
     p_jigsawRejected = false;
     p_ignore = false;
 
-    p_sample = 0.0;
-    p_line = 0.0;
+    p_sample = Isis::Null;//0.0;
+    p_line = Isis::Null; //0.0;
   }
 
 

--- a/isis/src/control/objs/ControlNetDiff/ControlNetDiff.cpp
+++ b/isis/src/control/objs/ControlNetDiff/ControlNetDiff.cpp
@@ -104,7 +104,7 @@ namespace Isis {
 
     Pvl net1Pvl = cnv1.toPvl();
     Pvl net2Pvl = cnv2.toPvl();
-
+    
     PvlObject &net1Obj = net1Pvl.findObject("ControlNetwork");
     PvlObject &net2Obj = net2Pvl.findObject("ControlNetwork");
     

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -1411,13 +1411,6 @@ namespace Isis {
     // serial number is required, no need for if-statement
     newMeasure->SetCubeSerialNumber(QString(measure.serialnumber().c_str()));
 
-    if ( measure.has_choosername() ) {
-      newMeasure->SetChooserName(QString(measure.choosername().c_str()));
-    }
-    if ( measure.has_datetime() ) {
-      newMeasure->SetDateTime(QString(measure.datetime().c_str()));
-    }
-
     // measure type is required, no need for if-statement
     ControlMeasure::MeasureType measureType;
     switch ( measure.type() ) {
@@ -1480,6 +1473,14 @@ namespace Isis {
         logEntry.SetNumericalValue( protoLog.doubledatavalue() );
       }
       newMeasure->SetLogData(logEntry);
+    }
+
+    if ( measure.has_choosername() ) {
+      newMeasure->SetChooserName(QString(measure.choosername().c_str()));
+    }
+
+    if ( measure.has_datetime() ) {
+      newMeasure->SetDateTime(QString(measure.datetime().c_str()));
     }
 
     // It is VERY important that the edit lock flag is set last because it prevents

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -454,12 +454,12 @@ namespace Isis {
           pvlMeasure += PvlKeyword("Ignore", "True");
         }
 
-        if ( controlMeasure.GetSample() != 0.0 ) {
+        if ( controlMeasure.GetSample() != Isis::Null) {
           pvlMeasure += PvlKeyword("Sample", toString(controlMeasure.GetSample()));
 
         }
 
-        if ( controlMeasure.GetLine() != 0.0 ) {
+        if ( controlMeasure.GetLine() != Isis::Null ) {
           pvlMeasure += PvlKeyword("Line", toString(controlMeasure.GetLine()));
         }
 
@@ -1854,11 +1854,11 @@ namespace Isis {
           protoMeasure.set_jigsawrejected(true);
         }
 
-        if ( controlMeasure.GetSample() != 0.0 ) {
+        if ( controlMeasure.GetSample() != Isis::Null ) {
           protoMeasure.set_sample(controlMeasure.GetSample());
         }
 
-        if ( controlMeasure.GetLine() != 0.0 ) {
+        if ( controlMeasure.GetLine() != Isis::Null ) {
           protoMeasure.set_line(controlMeasure.GetLine());
         }
 

--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0003.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0003.cpp
@@ -579,8 +579,9 @@ namespace Isis {
                                QSharedPointer<ControlPointFileEntryV0002> point,
                                void (ControlPointFileEntryV0002::*setter)(bool)) {
 
-    if (!container.hasKeyword(keyName))
+    if (!container.hasKeyword(keyName)) {
       return;
+    }
 
     QString value = container[keyName][0];
     container.deleteKeyword(keyName);
@@ -610,8 +611,9 @@ namespace Isis {
                                QSharedPointer<ControlPointFileEntryV0002> point,
                                void (ControlPointFileEntryV0002::*setter)(double)) {
 
-    if (!container.hasKeyword(keyName))
+    if (!container.hasKeyword(keyName)) {
       return;
+    }
 
     double value = toDouble(container[keyName][0]);
     container.deleteKeyword(keyName);
@@ -726,8 +728,9 @@ namespace Isis {
                                void (ControlPointFileEntryV0002_Measure::*setter)
                                       (const std::string &)) {
 
-    if (!container.hasKeyword(keyName))
+    if (!container.hasKeyword(keyName)) {
       return;
+    }
 
     QString value = container[keyName][0];
     container.deleteKeyword(keyName);


### PR DESCRIPTION
This should probably have been two PRs, sorry. Changes:
(1) I switched from initializing Sample, Line to 0.0, 0.0 to Isis::Null, Isis::Null.
(2) I switched where ControlMeasure's chooser name and date time are set so they are not wiped out by the other setter methods.
(3) Minor coding standards changes.