### PR TITLE
Fixed relevant issues to match ControlNetVersioner unit tests to truthdata.

### DIFF
--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
@@ -406,6 +406,7 @@ namespace Isis {
    */
   ControlMeasure::Status ControlMeasure::SetResidual(double sampResidual,
       double lineResidual) {
+        
     MeasureModified();
     p_sampleResidual = sampResidual;
     p_lineResidual   = lineResidual;
@@ -553,6 +554,10 @@ namespace Isis {
     }
   }
 
+  //! Returns true if the choosername is not empty.
+  bool ControlMeasure::HasChooserName() const {
+    return !p_chooserName->isEmpty();
+  }
 
   //! Return the serial number of the cube containing the coordinate
   QString ControlMeasure::GetCubeSerialNumber() const {
@@ -569,6 +574,12 @@ namespace Isis {
       return Application::DateTime();
     }
   }
+
+  //! Returns true if the datetime is not empty.
+  bool ControlMeasure::HasDateTime() const {
+    return !p_dateTime->isEmpty();
+  }
+
 
 
   //! Return the diameter of the crater in pixels (0 implies no crater)

--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.h
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.h
@@ -172,6 +172,9 @@ namespace Isis {
    *   @history 2017-12-21 Adam Goins - Removed protobuf references.
    *   @history 2018-01-04 Adam Goins - Moved sample/line initialization from the constructor
    *                           to the InitToNull() method.
+   *   @history 2018-01-05 Adam Goins - Added HasDateTime() and HasChooserName() methods to allow
+   *                           to allow the value of these variables to be read without being
+   *                           overriden if they're empty. (Getters override if they're empty).
    */
   class ControlMeasure : public QObject {
 
@@ -279,8 +282,10 @@ namespace Isis {
       double GetAprioriSample() const;
       Isis::Camera *Camera() const;
       QString GetChooserName() const;
+      bool HasChooserName() const;
       QString GetCubeSerialNumber() const;
       QString GetDateTime() const;
+      bool HasDateTime() const;
       double GetDiameter() const;
       ControlMeasureLogData GetLogData(long dataType) const;
       bool IsEditLocked() const;

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -242,11 +242,17 @@ namespace Isis {
       else {
         pvlPoint += PvlKeyword("PointId", controlPoint->GetId());
       }
-      if ( !controlPoint->GetChooserName().isEmpty() ) {
+      if ( controlPoint->HasChooserName() ) {
         pvlPoint += PvlKeyword("ChooserName", controlPoint->GetChooserName());
       }
-      if ( !controlPoint->GetDateTime().isEmpty() ) {
+      else {
+        pvlPoint += PvlKeyword("ChooserName", "");
+      }
+      if ( controlPoint->HasDateTime() ) {
         pvlPoint += PvlKeyword("DateTime", controlPoint->GetDateTime());
+      }
+      else {
+        pvlPoint += PvlKeyword("DateTime", "");
       }
       if ( controlPoint->IsEditLocked() ) {
         pvlPoint += PvlKeyword("EditLock", "True");
@@ -329,7 +335,11 @@ namespace Isis {
 
         // FIXME: None of Covariance matrix information is available directly from ControlPoint in the API
         symmetric_matrix<double, upper> aprioriCovarianceMatrix = aprioriSurfacePoint.GetRectangularMatrix();
-        if ( aprioriCovarianceMatrix.size1() > 0 ) {
+        if ( aprioriCovarianceMatrix.size1() > 0 &&
+             aprioriSurfacePoint.GetLatSigmaDistance().meters() != Isis::Null &&
+             aprioriSurfacePoint.GetLonSigmaDistance().meters() != Isis::Null &&
+             aprioriSurfacePoint.GetLocalRadiusSigma().meters() != Isis::Null) {
+
           PvlKeyword matrix("AprioriCovarianceMatrix");
           matrix += toString(aprioriCovarianceMatrix(0, 0));
           matrix += toString(aprioriCovarianceMatrix(0, 1));
@@ -440,14 +450,12 @@ namespace Isis {
             break;
         }
 
-        if ( !controlMeasure.GetChooserName().isEmpty() ) {
+        if ( controlMeasure.HasChooserName() ) {
           pvlMeasure += PvlKeyword("ChooserName", controlMeasure.GetChooserName());
         }
-
-        if ( !controlMeasure.GetDateTime().isEmpty() ) {
+        if ( controlMeasure.HasDateTime() ) {
           pvlMeasure += PvlKeyword("DateTime", controlMeasure.GetDateTime());
         }
-
         if ( controlMeasure.IsEditLocked() ) {
           pvlMeasure += PvlKeyword("EditLock", "True");
         }
@@ -562,6 +570,8 @@ namespace Isis {
     if ( controlNetwork.hasKeyword("Version") ) {
       version = toInt(controlNetwork["Version"][0]);
     }
+    std::cout << "Pvl Version: " << version << std::endl;
+
     switch ( version ) {
       case 1:
         readPvlV0001(controlNetwork);
@@ -914,7 +924,7 @@ namespace Isis {
       }
       catch (IException &e) {
         QString msg = "Failed to convert version 1 protobuf control point at index ["
-                      + toString(i) + "] into a ControlPoint.";
+                      + toString(i) + "] to a ControlPoint.";
         throw IException(e, IException::User, msg, _FILEINFO_);
       }
     }
@@ -1134,7 +1144,7 @@ namespace Isis {
       }
       catch (IException &e) {
         QString msg = "Failed to convert protobuf version 2 control point at index ["
-                      + toString(pointIndex) + "] into a ControlPoint.";
+                      + toString(pointIndex) + "] in a ControlPoint.";
         throw IException(e, IException::Io, msg, _FILEINFO_);
       }
     }
@@ -1649,10 +1659,10 @@ namespace Isis {
         protoPoint.set_id(controlPoint->GetId().toLatin1().data());
       }
 
-      if ( !controlPoint->GetChooserName().isEmpty() ) {
+      if ( controlPoint->HasChooserName() ) {
         protoPoint.set_choosername(controlPoint->GetChooserName().toLatin1().data());
       }
-      if ( !controlPoint->GetDateTime().isEmpty() ) {
+      if ( controlPoint->HasDateTime() ) {
         protoPoint.set_datetime(controlPoint->GetDateTime().toLatin1().data());
       }
       if ( controlPoint->IsEditLocked() ) {
@@ -1761,7 +1771,11 @@ namespace Isis {
         protoPoint.set_aprioriz(aprioriSurfacePoint.GetZ().meters());
 
         symmetric_matrix<double, upper> aprioriCovarianceMatrix = aprioriSurfacePoint.GetRectangularMatrix();
-        if ( aprioriCovarianceMatrix.size1() > 0 ) {
+        if ( aprioriCovarianceMatrix.size1() > 0 &&
+             aprioriSurfacePoint.GetLatSigmaDistance().meters() != Isis::Null &&
+             aprioriSurfacePoint.GetLonSigmaDistance().meters() != Isis::Null &&
+             aprioriSurfacePoint.GetLocalRadiusSigma().meters() != Isis::Null) {
+
           protoPoint.add_aprioricovar(aprioriCovarianceMatrix(0, 0));
           protoPoint.add_aprioricovar(aprioriCovarianceMatrix(0, 1));
           protoPoint.add_aprioricovar(aprioriCovarianceMatrix(0, 2));
@@ -1770,7 +1784,6 @@ namespace Isis {
           protoPoint.add_aprioricovar(aprioriCovarianceMatrix(2, 2));
         }
       }
-
       // this might be redundant... determined by covariance matrix???
       if ( controlPoint->IsLatitudeConstrained() ) {
         protoPoint.set_latitudeconstrained(controlPoint->IsLatitudeConstrained());
@@ -1832,11 +1845,11 @@ namespace Isis {
                 break;
         }
 
-        if ( !controlMeasure.GetChooserName().isEmpty() ) {
+        if ( controlMeasure.HasChooserName() ) {
           protoMeasure.set_choosername(controlMeasure.GetChooserName().toLatin1().data());
         }
 
-        if ( !controlMeasure.GetDateTime().isEmpty() ) {
+        if ( controlMeasure.HasDateTime() ) {
           protoMeasure.set_datetime(controlMeasure.GetDateTime().toLatin1().data());
         }
 

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -473,7 +473,8 @@ namespace Isis {
           pvlMeasure += PvlKeyword("Line", toString(controlMeasure.GetLine()));
         }
 
-        if ( controlMeasure.GetDiameter() != Isis::Null ) {
+        if ( controlMeasure.GetDiameter() != Isis::Null
+             && controlMeasure.GetDiameter() != 0. ) {
           pvlMeasure += PvlKeyword("Diameter", toString(controlMeasure.GetDiameter()));
         }
 
@@ -570,7 +571,6 @@ namespace Isis {
     if ( controlNetwork.hasKeyword("Version") ) {
       version = toInt(controlNetwork["Version"][0]);
     }
-    std::cout << "Pvl Version: " << version << std::endl;
 
     switch ( version ) {
       case 1:

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -924,7 +924,7 @@ namespace Isis {
       }
       catch (IException &e) {
         QString msg = "Failed to convert version 1 protobuf control point at index ["
-                      + toString(i) + "] to a ControlPoint.";
+                      + toString(i) + "] into a ControlPoint.";
         throw IException(e, IException::User, msg, _FILEINFO_);
       }
     }
@@ -1144,7 +1144,7 @@ namespace Isis {
       }
       catch (IException &e) {
         QString msg = "Failed to convert protobuf version 2 control point at index ["
-                      + toString(pointIndex) + "] in a ControlPoint.";
+                      + toString(pointIndex) + "] into a ControlPoint.";
         throw IException(e, IException::Io, msg, _FILEINFO_);
       }
     }

--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -75,7 +75,6 @@ namespace Isis {
          m_pointData, &ControlNetFileProtoV0001_PBControlPoint::set_longitudeconstrained);
     copy(pointObject, "RadiusConstrained",
          m_pointData, &ControlNetFileProtoV0001_PBControlPoint::set_radiusconstrained);
-
     // Copy over the adjusted surface point
     if ( pointObject.hasKeyword("Latitude")
          && pointObject.hasKeyword("Longitude")
@@ -392,7 +391,7 @@ namespace Isis {
         }
         catch (...) {
           value = 0;
-          m_pointData->set_ignore(true);
+          measure.set_ignore(true);
         }
         measure.mutable_measurement()->set_sample(value);
         group.deleteKeyword("Sample");
@@ -406,7 +405,7 @@ namespace Isis {
         }
         catch (...) {
           value = 0;
-          m_pointData->set_ignore(true);
+          measure.set_ignore(true);
         }
         measure.mutable_measurement()->set_line(value);
         group.deleteKeyword("Line");
@@ -542,6 +541,7 @@ namespace Isis {
                     "points or measures";
       throw IException(IException::Io, msg, _FILEINFO_);
     }
+
   }
 
 
@@ -704,11 +704,13 @@ namespace Isis {
                                ControlNetFileProtoV0001_PBControlPoint_PBControlMeasure &measure,
                                void (ControlNetFileProtoV0001_PBControlPoint_PBControlMeasure::*setter)(double)) {
 
-    if (!container.hasKeyword(keyName))
-      return;
+    double value = Isis::Null;
+    if ( container.hasKeyword(keyName) ) {
+      value = toDouble(container[keyName][0]);
+      container.deleteKeyword(keyName);
 
-    double value = toDouble(container[keyName][0]);
-    container.deleteKeyword(keyName);
+    }
+
     (measure.*setter)(value);
   }
 
@@ -733,8 +735,9 @@ namespace Isis {
                                void (ControlNetFileProtoV0001_PBControlPoint_PBControlMeasure::*setter)
                                       (const std::string &)) {
 
-    if (!container.hasKeyword(keyName))
+    if (!container.hasKeyword(keyName)) 
       return;
+
 
     QString value = container[keyName][0];
     container.deleteKeyword(keyName);

--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -10,6 +10,7 @@
 #include "NaifStatus.h"
 #include "Pvl.h"
 #include "PvlContainer.h"
+#include "SpecialPixel.h"
 #include "SurfacePoint.h"
 #include "Target.h"
 
@@ -420,16 +421,21 @@ namespace Isis {
         measure.mutable_measurement()->set_lineresidual(value);
         group.deleteKeyword("ErrorLine");
       }
+
+      double sampleResidualValue = Isis::Null;
       if (group.hasKeyword("SampleResidual")) {
-        double value = toDouble(group["SampleResidual"][0]);
-        measure.mutable_measurement()->set_sampleresidual(value);
+        sampleResidualValue = toDouble(group["SampleResidual"][0]);
         group.deleteKeyword("SampleResidual");
       }
+      measure.mutable_measurement()->set_sampleresidual(sampleResidualValue);
+
+      double lineResidualValue = Isis::Null;
       if (group.hasKeyword("LineResidual")) {
-        double value = toDouble(group["LineResidual"][0]);
-        measure.mutable_measurement()->set_lineresidual(value);
+        lineResidualValue = toDouble(group["LineResidual"][0]);
         group.deleteKeyword("LineResidual");
       }
+      measure.mutable_measurement()->set_lineresidual(lineResidualValue);
+
       if (group.hasKeyword("Reference")) {
         if (group["Reference"][0].toLower() == "true") {
           m_pointData->set_referenceindex(groupIndex);

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
 }
 
 void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
-  std::cout << "Reading: " << filename << "...\n";
+  std::cout << "\nReading: " << filename << "...\n";
   FileName networkFileName(filename);
 
   ControlNetVersioner *test = NULL;
@@ -43,7 +43,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     //   convert to Pvl, then update, then convert to binary, and back to pvl.
     //   The reason for the intermediate Pvl is described in
     //   ControlNetVersioner.h.
-    std::cout << "Read network..." << std::endl;
+    std::cout << "\nRead network..." << std::endl;
     test = new ControlNetVersioner(networkFileName);
 
     if(printNetwork) {
@@ -162,5 +162,4 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     test2 = NULL;
   }
 
-  std::cout << std::endl;
 }

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -62,7 +62,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
       test2 = new ControlNetVersioner( FileName("./tmp") );
     }
     catch(IException &e) {
-      //remove("./tmp");
+      remove("./tmp");
       throw;
     }
 
@@ -133,17 +133,17 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
         std::cout << "The conversion methods for pvl->bin and bin->pvl are correct." << std::endl;
       }
 
-      //remove("./tmpCNet2");
+      remove("./tmpCNet2");
       delete cNet2;
       cNet2 = NULL;
     }
 
-    //remove("./tmp");
-    //remove("./tmp2");
+    remove("./tmp");
+    remove("./tmp2");
 
     if(printNetwork) {
-      //remove("./tmp.pvl");
-      //remove("./tmp2.pvl");
+      remove("./tmp.pvl");
+      remove("./tmp2.pvl");
     }
   }
   catch(IException &e) {

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -1,6 +1,5 @@
 #include "ControlNetVersioner.h"
 
-#include <QDebug>
 #include <QString>
 #include <QTime>
 
@@ -18,7 +17,7 @@ void TestNetwork(const QString &filename, bool printNetwork = true, bool pvlInpu
 
 int main(int argc, char *argv[]) {
   Preference::Preferences(true);
-  qDebug() << "Test ControlNetVersioner";
+  std::cout << "Test ControlNetVersioner";
 
   TestNetwork("$control/testData/unitTest_ControlNetVersioner_reallyOldNetwork_PvlV0001.net");   // No target
   TestNetwork("$control/testData/unitTest_ControlNetVersioner_reallyOldNetwork2_PvlV0001.net");  // Really odd keywords with target
@@ -30,7 +29,7 @@ int main(int argc, char *argv[]) {
 }
 
 void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
-  qDebug() << "Reading: " << filename << "...\n";
+  std::cout << "Reading: " << filename << "...\n";
   FileName networkFileName(filename);
 
   ControlNetVersioner *test = NULL;
@@ -44,55 +43,55 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     //   convert to Pvl, then update, then convert to binary, and back to pvl.
     //   The reason for the intermediate Pvl is described in
     //   ControlNetVersioner.h.
-    qDebug() << "Read network...";
+    std::cout << "Read network..." << std::endl;
     test = new ControlNetVersioner(networkFileName);
 
     if(printNetwork) {
-      qDebug() << "Converted directly to Pvl:";
+      std::cout << "Converted directly to Pvl:" << std::endl;
       Pvl pvlVersion(test->toPvl());
 
-      // qDebug() does not support this operation on a pvl
+      // std::cout does not support this operation on a pvl
       std::cout << pvlVersion << std::endl;
       pvlVersion.write("./tmp.pvl");
     }
 
     // Test the latest binary read/write and Pvl conversion
-    qDebug() << "Write the network and re-read it...";
+    std::cout << "Write the network and re-read it..." << std::endl;
     test->write( FileName("./tmp") );
     try {
       test2 = new ControlNetVersioner( FileName("./tmp") );
     }
     catch(IException &e) {
-      remove("./tmp");
+      //remove("./tmp");
       throw;
     }
 
-    qDebug() << "After reading and writing to a binary form does Pvl match?";
+    std::cout << "After reading and writing to a binary form does Pvl match?" << std::endl;
 
     if(printNetwork) {
       Pvl pvlVersion2(test2->toPvl());
       pvlVersion2.write("./tmp2.pvl");
       if(system("cmp ./tmp.pvl ./tmp2.pvl")) {
-        qDebug() << "Reading/Writing results in Pvl differences!";
+        std::cout << "Reading/Writing results in Pvl differences!" << std::endl;
       }
       else {
-        qDebug() << "Conversion to Pvl stays consistent";
+        std::cout << "Conversion to Pvl stays consistent" << std::endl;
       }
     }
 
     test2->write(FileName("./tmp2"));
     if(system("cmp ./tmp ./tmp2")) {
-      qDebug() << "Reading/Writing control network results in binary differences!";
+      std::cout << "Reading/Writing control network results in binary differences!" << std::endl;
     }
     else {
-      qDebug() << "Reading/Writing control network is consistent";
+      std::cout << "Reading/Writing control network is consistent" << std::endl;
     }
 
     if (pvlInput) {
 
       ControlNetVersioner *cNet2 = NULL;
 
-      qDebug() << "Check conversions between the binary format and the pvl format.";
+      std::cout << "Check conversions between the binary format and the pvl format." << std::endl;
       /*
        * When the input is a pvl, ./tmp is the binary form of the initial input. (pvl1->bin1)
        * Furthermore, ./tmp.pvl is the first binary conversion reverted back to pvl.
@@ -124,33 +123,33 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
 
         //if the binary files are different.
         if(system("diff -EbB --suppress-common-lines ./tmp ./tmpCNet2")){
-          qDebug() << "The conversion from binary to pvl is incorrect.";
+          std::cout << "The conversion from binary to pvl is incorrect." << std::endl;
         }
         else {
-          qDebug() << "The conversion from pvl to binary is incorrect.";
+          std::cout << "The conversion from pvl to binary is incorrect." << std::endl;
         }
       }
       else {
-        qDebug() << "The conversion methods for pvl->bin and bin->pvl are correct.";
+        std::cout << "The conversion methods for pvl->bin and bin->pvl are correct." << std::endl;
       }
 
-      remove("./tmpCNet2");
+      //remove("./tmpCNet2");
       delete cNet2;
       cNet2 = NULL;
     }
 
-    remove("./tmp");
-    remove("./tmp2");
+    //remove("./tmp");
+    //remove("./tmp2");
 
     if(printNetwork) {
-      remove("./tmp.pvl");
-      remove("./tmp2.pvl");
+      //remove("./tmp.pvl");
+      //remove("./tmp2.pvl");
     }
   }
   catch(IException &e) {
     QStringList errors = e.toString().split("\n");
     errors.removeLast();
-    qDebug() << errors.join("\n");
+    std::cout << errors.join("\n") << std::endl;
   }
 
   if(test) {
@@ -163,5 +162,5 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     test2 = NULL;
   }
 
-  qDebug();
+  std::cout << std::endl;
 }

--- a/isis/src/control/objs/ControlPoint/ControlPoint.cpp
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.cpp
@@ -1212,6 +1212,16 @@ namespace Isis {
     }
   }
 
+  //! Returns true if the choosername is not empty.
+  bool ControlPoint::HasChooserName() const {
+    return !chooserName.isEmpty();
+  }
+
+  //! Returns true if the datetime is not empty.
+  bool ControlPoint::HasDateTime() const {
+    return !dateTime.isEmpty();
+  }
+
 
   QString ControlPoint::GetDateTime() const {
     if (dateTime != "") {
@@ -1531,15 +1541,15 @@ namespace Isis {
        const {
      return aprioriRadiusSource;
    }
- 
- 
+
+
    bool ControlPoint::HasAprioriCoordinates() {
      if (aprioriSurfacePoint.GetX().isValid() &&
          aprioriSurfacePoint.GetY().isValid() &&
          aprioriSurfacePoint.GetZ().isValid()) {
        return true;
      }
- 
+
      return false;
      // return aprioriSurfacePoint.Valid(); ???
    }

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -340,6 +340,9 @@ namespace Isis {
    *                            HasRefMeasure().
    *   @history 2017-12-21 Adam Goins - Removed redundant code following ControlNetVersioner
    *                           refactor.
+   *   @history 2018-01-05 Adam Goins - Added HasDateTime() and HasChooserName() methods to allow
+   *                           to allow the value of these variables to be read without being
+   *                           overriden if they're empty. (Getters override if they're empty).
    */
   class ControlPoint : public QObject {
 
@@ -536,6 +539,8 @@ namespace Isis {
       int GetNumValidMeasures() const;
       int GetNumLockedMeasures() const;
       bool HasSerialNumber(QString serialNumber) const;
+      bool HasChooserName() const;
+      bool HasDateTime() const;
       int IndexOf(ControlMeasure *, bool throws = true) const;
       int IndexOf(QString sn, bool throws = true) const;
       int IndexOfRefMeasure() const;


### PR DESCRIPTION
(1): Added HasChooserName() and HasDateTime() methods to ControlPoint and ControlMeasure to allow us to check if these values are empty without overriding them. (Using the GetChooserName() and GetDateTime() would override these values if they were empty).

(2): Added checks for Apriori Lat/Long values to ensure that they're not Null before we write them. These values were being written previously because we were only checking if aprioriCovarianceMatrix.size1() > 0 before writing the matrix.

(3): In ControlPointV0001, fixed an issue where we were seeting ControlPoint::Ignore to true where we should be setting the measure to true.

(4): In ControlPointV0001, initialize double values to Isis::Null by default. Some values were reading in with a default of 0. 

(5): Updated ControlNetVersioner's unitTest to match truthdata spacing. 