### PR TITLE
Adjust indexing after removing an unused keyword from a Pvl group in …

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -487,11 +487,12 @@ namespace Isis {
       }
 
       // Clean up the remaining keywords
-      for (int cmKeyIndex = 0; cmKeyIndex < group.keywords(); cmKeyIndex ++) {
+      for (int cmKeyIndex = 0; cmKeyIndex < group.keywords(); cmKeyIndex++) {
         if (group[cmKeyIndex][0] == ""
             || group[cmKeyIndex].name() == "ZScore"
             || group[cmKeyIndex].name() == "ErrorMagnitude") {
           group.deleteKeyword(cmKeyIndex);
+          cmKeyIndex--;
         }
       }
 


### PR DESCRIPTION
…ControlPointV0001.

Not sure if this was the best way to handle this, but we were previously missing entries that needed to be removed because for example we'd have in the incoming group:

index 0  val ErrorMagnitude
index 1  val ZScore

Then we'd remove ErrorMagnitude, leaving us with 
index 0 val ZScore.

... and then ZScore would not be tested or removed because the index was already incremented to 1.