### PR TITLE
Updated ControlNetVersioner truthdata.

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
@@ -22,7 +22,6 @@ Object = ControlNetwork
   Object = ControlPoint
     PointType = Free
     PointId   = 1
-    DateTime  = Null
 
     Group = ControlMeasure
       SerialNumber = M0
@@ -69,7 +68,6 @@ Object = ControlNetwork
   Object = ControlPoint
     PointType = Fixed
     PointId   = 1001
-    DateTime  = Null
 
     Group = ControlMeasure
       SerialNumber = Cassini-Huygens/ISSNA/1/1467436709.122


### PR DESCRIPTION
Truthdata ignores datetime. This is pursuant to the discussion on 2018-01-09 where we decided to omit choosername/date if it's null/empty. 