### PR TITLE
Added to ability to toggle auto-resizability in QView AdvancedTrackTool columns. Fixes #5142.

### DIFF
--- a/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
+++ b/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
@@ -6,6 +6,7 @@
 #include <QStatusBar>
 #include <QDockWidget>
 #include <QFileDialog>
+#include <QHeaderView>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QSettings>
@@ -28,14 +29,15 @@ namespace Isis {
     p_visibleColumns = -1;
     p_currentRow = 0;
     p_currentIndex = 0;
-    createTable();
-
     setObjectName(title);
+    createTable();
     readSettings(QSize(500, 300));
+    readColumnSettings();
   }
 
 
   TableMainWindow::~TableMainWindow() {
+    writeSettings();
   }
 
 
@@ -57,6 +59,23 @@ namespace Isis {
     return result;
   }
 
+  void TableMainWindow::resizeColumn(int columnIndex) {
+    QHeaderView* header = p_table->horizontalHeader();
+
+    QString columnName(p_table->model()->headerData(columnIndex, Qt::Horizontal).toString());
+
+    if (columnName.isEmpty())
+    {
+      return;
+    }
+
+    if (header->sectionResizeMode(columnIndex) == QHeaderView:: ResizeToContents) {
+      header->setSectionResizeMode(columnIndex, QHeaderView::Interactive);
+    }
+    else {
+      header->setSectionResizeMode(columnIndex, QHeaderView::ResizeToContents);
+    }
+  }
 
   /**
    * This creates the table main window.  The table and docking
@@ -77,6 +96,12 @@ namespace Isis {
     // Create the table widget
     p_table = new QTableWidget(this);
     p_table->setAlternatingRowColors(true);
+    //
+    QHeaderView* columnHeader = p_table->horizontalHeader();
+    columnHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
+    connect ( columnHeader, SIGNAL( sectionPressed(int) ),
+              this, SLOT( resizeColumn(int) ) );
+
     setCentralWidget(p_table);
 
     // Create the dock area
@@ -151,7 +176,6 @@ namespace Isis {
     cols->setText("Columns");
     connect(cols, SIGNAL(triggered()), p_dock, SLOT(show()));
     viewMenu->addAction(cols);
-
     this->setMenuBar(menuBar);
     installEventFilter(this);
   }
@@ -198,7 +222,7 @@ namespace Isis {
         destinationColumn = startCol + i;
         p_table->insertColumn(startCol + i);
       }
-      
+
       QTableWidgetItem *header = new QTableWidgetItem(htext);
       if (insertAt >= 0) {
 
@@ -255,6 +279,7 @@ namespace Isis {
 
       readItemSettings(heading, item, setOn);
     }
+    readColumnSettings();
   }
 
 
@@ -345,7 +370,7 @@ namespace Isis {
   /**
    * This method checks to see if the table has been created. If
    * not it calls the createTable method before calling show.
-   * 
+   *
    * @history 2017-10-06 Adam Goins - showTable() now calls syncColumns() after it calls
    *                        this->show() so that it hides the unselected columns appropriately.
    *                        Fixes #5141.
@@ -550,6 +575,41 @@ namespace Isis {
     item->setCheckState(state);
   }
 
+  /**
+   * This method reads the columns in the table and sets their size
+   * to the appropriate size, or the size to auto based on what they were
+   * stored as.
+   *
+   * @param heading
+   * @param item
+   */
+  void TableMainWindow::readColumnSettings() {
+
+    QHeaderView* header = p_table->horizontalHeader();
+    QSettings settings(settingsFileName(), QSettings::NativeFormat);
+
+    for(int columnIndex = 0; columnIndex < p_table->model()->columnCount(); columnIndex++)
+    {
+       QString headerName = p_table->model()->headerData(columnIndex, Qt::Horizontal).toString();
+
+       QString settingName = "column-" + headerName;
+
+       QString value = settings.value(settingName, "auto").toString();
+
+       if (value == "auto" || value == "0")
+       {
+          header->setSectionResizeMode(columnIndex, QHeaderView::ResizeToContents);
+       }
+       else
+       {
+         int width = value.toInt();
+
+         header->setSectionResizeMode(columnIndex, QHeaderView::Interactive);
+         p_table->setColumnWidth(columnIndex, width);
+       }
+    }
+  }
+
 
   /**
    * This overriden method is called when the Tablemainwindow
@@ -565,6 +625,22 @@ namespace Isis {
       foreach (QListWidgetItem *item, itemList()) {
         QString itemTitle = "item-" + item->text();
         settings.setValue(itemTitle, item->checkState());
+      }
+
+      QHeaderView *header = p_table->horizontalHeader();
+      for(int columnIndex = 0; columnIndex < p_table->model()->columnCount(); columnIndex++)
+      {
+         QString headerName = p_table->model()->headerData(columnIndex, Qt::Horizontal).toString();
+         QString settingName = "column-" + headerName;
+
+         if (header->sectionResizeMode(columnIndex) == QHeaderView::ResizeToContents)
+         {
+           settings.setValue(settingName, "auto");
+         }
+         else
+         {
+           settings.setValue( settingName, header->sectionSize(columnIndex) );
+         }
       }
     }
   }

--- a/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
+++ b/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
@@ -580,12 +580,10 @@ namespace Isis {
    * to the appropriate size, or the size to auto based on what they were
    * stored as.
    *
-   * @param heading
-   * @param item
    */
   void TableMainWindow::readColumnSettings() {
 
-    QHeaderView* header = p_table->horizontalHeader();
+    QHeaderView *header = p_table->horizontalHeader();
     QSettings settings(settingsFileName(), QSettings::NativeFormat);
 
     for(int columnIndex = 0; columnIndex < p_table->model()->columnCount(); columnIndex++)
@@ -616,6 +614,11 @@ namespace Isis {
    * is closed or hidden to write the size and location settings
    * (and dock widget settings) to a config file in the user's
    * home directory.
+   *
+   *  @internal
+   *    @history 2017-11-13 Adam Goins - Added the behavior of columns sizes to be written
+   *                            to the settings file so that they can be persistent through
+   *                            new instances of qview.
    *
    */
   void TableMainWindow::writeSettings() const {

--- a/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
+++ b/isis/src/qisis/objs/TableMainWindow/TableMainWindow.cpp
@@ -3,13 +3,13 @@
 #include <iostream>
 
 #include <QAction>
-#include <QStatusBar>
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QHeaderView>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QSettings>
+#include <QStatusBar>
 #include <QTableWidget>
 #include <QToolBar>
 
@@ -586,20 +586,16 @@ namespace Isis {
     QHeaderView *header = p_table->horizontalHeader();
     QSettings settings(settingsFileName(), QSettings::NativeFormat);
 
-    for(int columnIndex = 0; columnIndex < p_table->model()->columnCount(); columnIndex++)
-    {
+    for (int columnIndex = 0; columnIndex < p_table->model()->columnCount(); columnIndex++) {
+
        QString headerName = p_table->model()->headerData(columnIndex, Qt::Horizontal).toString();
-
        QString settingName = "column-" + headerName;
-
        QString value = settings.value(settingName, "auto").toString();
 
-       if (value == "auto" || value == "0")
-       {
+       if (value == "auto" || value == "0") {
           header->setSectionResizeMode(columnIndex, QHeaderView::ResizeToContents);
        }
-       else
-       {
+       else {
          int width = value.toInt();
 
          header->setSectionResizeMode(columnIndex, QHeaderView::Interactive);

--- a/isis/src/qisis/objs/TableMainWindow/TableMainWindow.h
+++ b/isis/src/qisis/objs/TableMainWindow/TableMainWindow.h
@@ -44,6 +44,11 @@ namespace Isis {
   *   @history 2017-10-06 Adam Goins - showTable() now calls syncColumns() after it calls
   *                          this->show() so that it hides the unselected columns appropriately.
   *                          Fixes #5141.
+  *   @history 2017-11-13 Adam Goins - modified createTable() to set the resize property of the
+  *                          columns to resize automatically based on the content inside of the
+  *                          column. Added resizeColumn() slot and readColumnSettings().
+  *                          modifie writeSettings() to write updated settings on destroy.
+  *                          Added Fixes #5142.
   */
   class TableMainWindow : public MainWindow {
       Q_OBJECT
@@ -129,6 +134,7 @@ namespace Isis {
       bool trackListItems();
       void loadTable();
       void writeSettings() const;
+      void resizeColumn(int columnIndex);
 
     signals:
       /**
@@ -142,6 +148,8 @@ namespace Isis {
       void createTable();
       void readItemSettings(QString heading, QListWidgetItem *item,
                             bool defaultChecked);
+
+      void readColumnSettings();
 
     private:
       std::string p_appName; //!< The application name

--- a/isis/src/qisis/objs/TableMainWindow/TableMainWindow.h
+++ b/isis/src/qisis/objs/TableMainWindow/TableMainWindow.h
@@ -44,11 +44,13 @@ namespace Isis {
   *   @history 2017-10-06 Adam Goins - showTable() now calls syncColumns() after it calls
   *                          this->show() so that it hides the unselected columns appropriately.
   *                          Fixes #5141.
-  *   @history 2017-11-13 Adam Goins - modified createTable() to set the resize property of the
-  *                          columns to resize automatically based on the content inside of the
-  *                          column. Added resizeColumn() slot and readColumnSettings().
-  *                          modifie writeSettings() to write updated settings on destroy.
-  *                          Added Fixes #5142.
+  *   @history 2017-11-13 Adam Goins - Afforded TableMainWindow the ability to toggle between auto
+  *                          resizing columns or setting a specific column size for each column.
+  *                          modified createTable() to set the resize property of the columns to
+  *                          resize automatically based on the content inside of the column.
+  *                          Added resizeColumn() slot and readColumnSettings().
+  *                          modified writeSettings() to write updated settings on destroy.
+  *                          Fixes #5142.
   */
   class TableMainWindow : public MainWindow {
       Q_OBJECT


### PR DESCRIPTION
Afforded users the ability to toggle column autoresizability in the qview AdvancedTrackTool table columns.
Made the column size save to file so that it's persistent through qview instances.